### PR TITLE
feat(ci): drop Node.js v10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "Kenan Yildirim <kenan@kenany.me> (https://kenany.me/)",
   "engines": {
-    "node": ">=10"
+    "node": "12 || 14 || >=16"
   },
   "main": "dist/index.js",
   "jsnext:main": "dist/index.es.js",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported.